### PR TITLE
feat: Add copy button in detail page for 3 sections

### DIFF
--- a/lib/features/translation_feature/presentation/widgets/details_column_widget.dart
+++ b/lib/features/translation_feature/presentation/widgets/details_column_widget.dart
@@ -1,19 +1,26 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
+import '../../../../app/utils/app_assets.dart';
 import '../../../../app/utils/app_colors.dart';
+import '../../../../app/widgets/flutter_toast.dart';
+import '../../../../app/widgets/image_widget.dart';
+import '../../../../app/widgets/text_button_widget.dart';
 import '../../../../app/widgets/text_widget.dart';
 
 class DetailsColumnWidget extends StatelessWidget {
   final String title;
   final String? description;
   final double? descriptionFontSize;
+  final bool isCopy;
 
   const DetailsColumnWidget({
     super.key,
     required this.title,
     this.description,
     this.descriptionFontSize,
+    this.isCopy = false
   });
 
   @override
@@ -27,12 +34,28 @@ class DetailsColumnWidget extends StatelessWidget {
           color: AppColors.primaryColor,
           fontSize: 14.sp,
         ),
-        TextWidget(
-          title: description ?? '',
-          fontWeight: FontWeight.w400,
-          titleAlign: TextAlign.start,
-          maxLines: 10,
-          fontSize: descriptionFontSize?? 14.sp,
+        Row(
+          children: [
+            TextWidget(
+              title: description ?? '',
+              fontWeight: FontWeight.w400,
+              titleAlign: TextAlign.start,
+              maxLines: 10,
+              fontSize: descriptionFontSize?? 14.sp,
+            ),
+            if (isCopy) CustomTextButton(
+              onPressed: () {
+                // Copy to clipboard
+                Clipboard.setData(ClipboardData(text: description ?? ''));
+                showToast(msg: 'تم النسخ');
+              },
+              icon: ImageWidget(
+                imageUrl: AppAssets.copy,
+                width: 15.w,
+                height: 15.h,
+              ),
+            ),
+          ],
         ),
         10.verticalSpace,
       ],

--- a/lib/features/translation_feature/presentation/widgets/details_column_widget.dart
+++ b/lib/features/translation_feature/presentation/widgets/details_column_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 
 import '../../../../app/utils/app_assets.dart';
 import '../../../../app/utils/app_colors.dart';
@@ -46,6 +47,7 @@ class DetailsColumnWidget extends StatelessWidget {
             if (isCopy) CustomTextButton(
               onPressed: () {
                 // Copy to clipboard
+                Fluttertoast.cancel();
                 Clipboard.setData(ClipboardData(text: description ?? ''));
                 showToast(msg: 'تم النسخ');
               },

--- a/lib/features/translation_feature/presentation/widgets/translation_widget.dart
+++ b/lib/features/translation_feature/presentation/widgets/translation_widget.dart
@@ -4,6 +4,7 @@ import 'package:bastet_app/features/translation_feature/presentation/screens/tra
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 import 'package:share_plus/share_plus.dart';
 
 import '../../../../app/utils/app_assets.dart';
@@ -159,6 +160,7 @@ class TranslationWidget extends StatelessWidget {
                   const Spacer(),
                   CustomTextButton(
                     onPressed: () {
+                      Fluttertoast.cancel();
                       // Copy to clipboard
                       Clipboard.setData(ClipboardData(text: egyptian));
                       showToast(msg: 'تم النسخ');

--- a/lib/features/translation_feature/presentation/widgets/translation_widget.dart
+++ b/lib/features/translation_feature/presentation/widgets/translation_widget.dart
@@ -114,15 +114,18 @@ class TranslationWidget extends StatelessWidget {
                     DetailsColumnWidget(
                       title: 'القيمة الصوتية الإنجليزية:',
                       description: translationDetails?.egyptian?[0].transliteration,
+                      isCopy: true,
                     ),
                     DetailsColumnWidget(
                       title: 'الهيروغليفية:',
                       description: hieroglyphicSigns,
                       descriptionFontSize: 16.sp,
+                      isCopy: true,
                     ),
                     DetailsColumnWidget(
                       title: 'علامات جاردنير:',
                       description: hieroglyphics,
+                      isCopy: true,
                     ),
                     DetailsColumnWidget(
                       title: 'المصادر:',


### PR DESCRIPTION
# Motivation
people mentioned to me that they needed to copy the entire hieroglyphics signs, even I wanted to do that sometimes

# Description
I added a copy button to three sections as in the picture below on the details page

## Screenshot
![image](https://github.com/user-attachments/assets/1543cb41-6044-41a2-b019-bbf01762bdd3)
