### PR TITLE
Add dictionary screen

### DIFF
--- a/.metadata
+++ b/.metadata
@@ -15,7 +15,7 @@ migration:
     - platform: root
       create_revision: b25305a8832cfc6ba632a7f87ad455e319dccce8
       base_revision: b25305a8832cfc6ba632a7f87ad455e319dccce8
-    - platform: macos
+    - platform: ios
       create_revision: b25305a8832cfc6ba632a7f87ad455e319dccce8
       base_revision: b25305a8832cfc6ba632a7f87ad455e319dccce8
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,7 +3,8 @@
     <application
         android:label="Bastet"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:enableOnBackInvokedCallback="true">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/lib/app/utils/app_colors.dart
+++ b/lib/app/utils/app_colors.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-class AppColors{
+
+class AppColors {
   static const black = Color(0xFF000000);
   static const white = Color(0xFFFFFFFF);
   static const primaryColor = Color(0xFFE7B133);
@@ -24,15 +25,13 @@ class AppColors{
   static const inactiveSwitchThumbColor = Color(0xFFE6E0E9);
   static const activeSwitchColor = Color(0xFFD39F26);
 
+  // Dictionary category colors
+  static const dictionaryCategoryBackground = Color(0xFF3D3525);
+  static const dictionaryCategoryBorder = Color(0xFFE0B85B);
+  static const dictionaryCategoryText = Color(0xFFB1975C);
+
   static const red = Color(0xffEB5757);
   static const hint = Color(0xFFD1D1D1);
   static const grey24 = Color(0x24000000);
   static const descriptionColor = Color(0xFF82808D);
 }
-
-
-
-
-
-
-

--- a/lib/app/utils/consts.dart
+++ b/lib/app/utils/consts.dart
@@ -7,6 +7,7 @@ const String kWord = 'word';
 const String kLiteralTranslation = 'literal-translation';
 const String kWordSuggestion = 'word-suggestion';
 const String kPrivacyPolicy = 'privacy-policy';
+const String kCategory = 'category';
 
 /// Hive Boxes
 const String kFavoritesBox = 'favoritesBox';

--- a/lib/app/utils/consts.dart
+++ b/lib/app/utils/consts.dart
@@ -12,9 +12,6 @@ const String kCategory = 'category';
 /// Hive Boxes
 const String kFavoritesBox = 'favoritesBox';
 
-/// SharedPreferences Keys
-const String kSelectedDictionaryCategory = 'selectedDictionaryCategory';
-
 //Static Headers
 Map<String, String> apiHeaders = {
   "Content-Type": "application/json",

--- a/lib/app/utils/consts.dart
+++ b/lib/app/utils/consts.dart
@@ -12,6 +12,9 @@ const String kCategory = 'category';
 /// Hive Boxes
 const String kFavoritesBox = 'favoritesBox';
 
+/// SharedPreferences Keys
+const String kSelectedDictionaryCategory = 'selectedDictionaryCategory';
+
 //Static Headers
 Map<String, String> apiHeaders = {
   "Content-Type": "application/json",

--- a/lib/app/utils/get_it_injection.dart
+++ b/lib/app/utils/get_it_injection.dart
@@ -13,6 +13,7 @@ import '../../features/translation_feature/domain/usecases/get_translation_detai
 import '../../features/translation_feature/domain/usecases/get_translation_usecase.dart';
 import '../../features/translation_feature/domain/usecases/suggest_word_usecase.dart';
 import '../../features/translation_feature/domain/usecases/get_literal_translation_usecase.dart';
+import '../../features/translation_feature/domain/usecases/get_dictionary_category_words_usecase.dart';
 
 import '../network/network_info.dart';
 import '../network/network_manager.dart';
@@ -22,15 +23,23 @@ import 'navigation_helper.dart';
 final getIt = GetIt.instance;
 
 Future<void> init() async {
-
   //* Data sources
-  getIt.registerLazySingleton<TranslationRemoteDataSource>(() => TranslationRemoteDataSourceImpl(networkManager: getIt()),);
-  getIt.registerLazySingleton<SettingsRemoteDataSource>(() => SettingsRemoteDataSourceImpl(networkManager: getIt()),);
+  getIt.registerLazySingleton<TranslationRemoteDataSource>(
+    () => TranslationRemoteDataSourceImpl(networkManager: getIt()),
+  );
+  getIt.registerLazySingleton<SettingsRemoteDataSource>(
+    () => SettingsRemoteDataSourceImpl(networkManager: getIt()),
+  );
 
   //* Repository
-  getIt.registerLazySingleton<TranslationRepo>(() => TranslationRepoImpl(translationRemoteDataSource: getIt(), networkInfo: getIt()),);
-  getIt.registerLazySingleton<SettingsRepo>(() => SettingsRepoImpl(settingsRemoteDataSource: getIt(), networkInfo: getIt()),);
-
+  getIt.registerLazySingleton<TranslationRepo>(
+    () => TranslationRepoImpl(
+        translationRemoteDataSource: getIt(), networkInfo: getIt()),
+  );
+  getIt.registerLazySingleton<SettingsRepo>(
+    () => SettingsRepoImpl(
+        settingsRemoteDataSource: getIt(), networkInfo: getIt()),
+  );
 
   //* Use cases
   _translationUseCases();
@@ -41,18 +50,26 @@ Future<void> init() async {
   final sharedPreferences = await SharedPreferences.getInstance();
   getIt.registerLazySingleton<SharedPreferences>(() => sharedPreferences);
   getIt.registerLazySingleton<NetworkManager>(() => NetworkManager());
-  getIt.registerLazySingleton<DataConnectionChecker>(() => DataConnectionChecker());
+  getIt.registerLazySingleton<DataConnectionChecker>(
+      () => DataConnectionChecker());
   getIt.registerSingleton<NavHelper>(NavHelper());
   getIt.registerSingleton<CacheService>(CacheService());
 }
 
 void _translationUseCases() {
-  getIt.registerLazySingleton<GetTranslationUsecase>(() => GetTranslationUsecase(repository: getIt()));
-  getIt.registerLazySingleton<GetTranslationDetailsUseCase>(() => GetTranslationDetailsUseCase(repository: getIt()));
-  getIt.registerLazySingleton<GetLiteralTranslationUseCase>(() => GetLiteralTranslationUseCase(repository: getIt()));
-  getIt.registerLazySingleton<SuggestWordUsecase>(() => SuggestWordUsecase(repository: getIt()));
+  getIt.registerLazySingleton<GetTranslationUsecase>(
+      () => GetTranslationUsecase(repository: getIt()));
+  getIt.registerLazySingleton<GetTranslationDetailsUseCase>(
+      () => GetTranslationDetailsUseCase(repository: getIt()));
+  getIt.registerLazySingleton<GetLiteralTranslationUseCase>(
+      () => GetLiteralTranslationUseCase(repository: getIt()));
+  getIt.registerLazySingleton<SuggestWordUsecase>(
+      () => SuggestWordUsecase(repository: getIt()));
+  getIt.registerLazySingleton<GetDictionaryCategoryWordsUsecase>(
+      () => GetDictionaryCategoryWordsUsecase(repository: getIt()));
 }
 
 void _settingsUseCases() {
-  getIt.registerLazySingleton<GetPrivacyPolicyUseCase>(() => GetPrivacyPolicyUseCase(repository: getIt()));
+  getIt.registerLazySingleton<GetPrivacyPolicyUseCase>(
+      () => GetPrivacyPolicyUseCase(repository: getIt()));
 }

--- a/lib/features/dictionary_feature/data/dictionary_categories.dart
+++ b/lib/features/dictionary_feature/data/dictionary_categories.dart
@@ -1,0 +1,68 @@
+class DictionaryCategory {
+  final String id;
+  final String arabic;
+  final String english;
+
+  const DictionaryCategory({
+    required this.id,
+    required this.arabic,
+    required this.english,
+  });
+
+  String getDisplayName(String languageCode) {
+    return languageCode == "ar" ? arabic : english;
+  }
+}
+
+class DictionaryCategories {
+  static const List<DictionaryCategory> categories = [
+    DictionaryCategory(id: "gods", arabic: "آلهة", english: "gods"),
+    DictionaryCategory(id: "numbers", arabic: "أرقام", english: "numbers"),
+    DictionaryCategory(id: "family", arabic: "عائلة", english: "family"),
+    DictionaryCategory(id: "animals", arabic: "حيوانات", english: "animals"),
+    DictionaryCategory(id: "colors", arabic: "ألوان", english: "colors"),
+    DictionaryCategory(id: "food", arabic: "طعام", english: "food"),
+    DictionaryCategory(id: "body", arabic: "جسم", english: "body"),
+    DictionaryCategory(id: "symbols", arabic: "رموز", english: "symbols"),
+    DictionaryCategory(id: "greetings", arabic: "تحيات", english: "greetings"),
+    DictionaryCategory(id: "time", arabic: "وقت", english: "time"),
+    DictionaryCategory(id: "nature", arabic: "طبيعة", english: "nature"),
+    DictionaryCategory(id: "emotions", arabic: "مشاعر", english: "emotions"),
+    DictionaryCategory(id: "clothes", arabic: "ملابس", english: "clothes"),
+    DictionaryCategory(id: "music", arabic: "موسيقى", english: "music"),
+    DictionaryCategory(id: "home", arabic: "منزل", english: "home"),
+    DictionaryCategory(id: "stones", arabic: "أحجار", english: "stones"),
+    DictionaryCategory(id: "temples", arabic: "معابد", english: "temples"),
+    DictionaryCategory(id: "jobs", arabic: "وظائف", english: "jobs"),
+    DictionaryCategory(id: "adjective", arabic: "صفات", english: "adjective"),
+    DictionaryCategory(id: "verb", arabic: "افعال", english: "verb"),
+    DictionaryCategory(
+        id: "words_in_egyptian_dialect",
+        arabic: "كلمات في العامية",
+        english: "words in egyptians dialect"),
+    DictionaryCategory(
+        id: "prepositions", arabic: "حروف الجر", english: "prepositions"),
+    DictionaryCategory(id: "insects", arabic: "حشرات", english: "insects"),
+    DictionaryCategory(
+        id: "measurements", arabic: "قياسات", english: "measurements"),
+    DictionaryCategory(id: "countries", arabic: "دول", english: "countries"),
+    DictionaryCategory(
+        id: "egyptian_cities_provinces",
+        arabic: "مدن و محافظات",
+        english: "cities and provinces"),
+    DictionaryCategory(
+        id: "fruits_vegetables",
+        arabic: "فواكه و خضراوات",
+        english: "fruits and vegetables"),
+    DictionaryCategory(id: "plants", arabic: "نباتات", english: "plants"),
+    DictionaryCategory(id: "cosmos", arabic: "الكون", english: "cosmos"),
+    DictionaryCategory(
+        id: "female_names", arabic: "أسماء إناث", english: "female names"),
+    DictionaryCategory(
+        id: "male_names", arabic: "أسماء ذكور", english: "male names"),
+    DictionaryCategory(
+        id: "kings_queens",
+        arabic: "ملوك و ملكات",
+        english: "kings and queens"),
+  ];
+}

--- a/lib/features/dictionary_feature/presentation/dictionary_cubit.dart
+++ b/lib/features/dictionary_feature/presentation/dictionary_cubit.dart
@@ -17,19 +17,28 @@ class DictionaryCubit extends Cubit<DictionaryState> {
   List<Translation> categoryTranslations = [];
 
   Future<void> getCategoryWords(String categoryId) async {
-    emit(DictionaryLoading());
+    try {
+      emit(DictionaryLoading());
 
-    final response = await getIt<GetDictionaryCategoryWordsUsecase>()(
-      GetDictionaryCategoryWordsUseCaseParams(categoryId: categoryId),
-    );
+      // Clear the list immediately when loading new category
+      categoryTranslations = [];
 
-    response.fold(
-      errorStateHandler,
-      (translationModel) {
-        categoryTranslations = translationModel.translation ?? [];
-      },
-    );
+      final response = await getIt<GetDictionaryCategoryWordsUsecase>()(
+        GetDictionaryCategoryWordsUseCaseParams(categoryId: categoryId),
+      );
 
-    emit(DictionaryInitial());
+      response.fold(
+        errorStateHandler,
+        (translationModel) {
+          categoryTranslations = translationModel.translation ?? [];
+        },
+      );
+
+      emit(DictionaryInitial());
+    } catch (e) {
+      // Handle any unexpected errors
+      categoryTranslations = [];
+      emit(DictionaryInitial());
+    }
   }
 }

--- a/lib/features/dictionary_feature/presentation/dictionary_cubit.dart
+++ b/lib/features/dictionary_feature/presentation/dictionary_cubit.dart
@@ -1,0 +1,35 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../app/utils/get_it_injection.dart';
+import '../../../app/utils/handlers/error_state_handler.dart';
+import '../../../app/utils/navigation_helper.dart';
+import '../../translation_feature/data/model/translation.dart';
+import '../../translation_feature/domain/usecases/get_dictionary_category_words_usecase.dart';
+
+part 'dictionary_state.dart';
+
+class DictionaryCubit extends Cubit<DictionaryState> {
+  DictionaryCubit() : super(DictionaryInitial());
+  static DictionaryCubit get() =>
+      BlocProvider.of(getIt<NavHelper>().navigatorKey.currentState!.context);
+
+  List<Translation> categoryTranslations = [];
+
+  Future<void> getCategoryWords(String categoryId) async {
+    emit(DictionaryLoading());
+
+    final response = await getIt<GetDictionaryCategoryWordsUsecase>()(
+      GetDictionaryCategoryWordsUseCaseParams(categoryId: categoryId),
+    );
+
+    response.fold(
+      errorStateHandler,
+      (translationModel) {
+        categoryTranslations = translationModel.translation ?? [];
+      },
+    );
+
+    emit(DictionaryInitial());
+  }
+}

--- a/lib/features/dictionary_feature/presentation/dictionary_cubit.dart
+++ b/lib/features/dictionary_feature/presentation/dictionary_cubit.dart
@@ -11,8 +11,14 @@ part 'dictionary_state.dart';
 
 class DictionaryCubit extends Cubit<DictionaryState> {
   DictionaryCubit() : super(DictionaryInitial());
-  static DictionaryCubit get() =>
-      BlocProvider.of(getIt<NavHelper>().navigatorKey.currentState!.context);
+  static DictionaryCubit get() {
+    final currentState = getIt<NavHelper>().navigatorKey.currentState;
+    if (currentState == null) {
+      throw Exception(
+          "Navigator's currentState is null. Ensure the navigator is properly initialized.");
+    }
+    return BlocProvider.of(currentState.context);
+  }
 
   List<Translation> categoryTranslations = [];
 

--- a/lib/features/dictionary_feature/presentation/dictionary_state.dart
+++ b/lib/features/dictionary_feature/presentation/dictionary_state.dart
@@ -1,0 +1,15 @@
+part of 'dictionary_cubit.dart';
+
+sealed class DictionaryState extends Equatable {
+  const DictionaryState();
+}
+
+final class DictionaryInitial extends DictionaryState {
+  @override
+  List<Object> get props => [];
+}
+
+final class DictionaryLoading extends DictionaryState {
+  @override
+  List<Object> get props => [];
+}

--- a/lib/features/dictionary_feature/presentation/widgets/category_selector_widget.dart
+++ b/lib/features/dictionary_feature/presentation/widgets/category_selector_widget.dart
@@ -1,0 +1,66 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+import '../../../../app/utils/app_colors.dart';
+import '../../data/dictionary_categories.dart';
+
+class CategorySelectorWidget extends StatelessWidget {
+  final String selectedCategory;
+  final Future<void> Function(String) onCategorySelected;
+
+  const CategorySelectorWidget({
+    super.key,
+    required this.selectedCategory,
+    required this.onCategorySelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 40.h,
+      margin: EdgeInsets.only(
+        top: 10.h,
+        bottom: 25.h,
+        right: 8.w,
+        left: 8.w,
+      ),
+      child: ListView.builder(
+        scrollDirection: Axis.horizontal,
+        itemCount: DictionaryCategories.categories.length,
+        itemBuilder: (context, index) {
+          final category = DictionaryCategories.categories[index];
+          final isSelected = selectedCategory == category.id;
+
+          return GestureDetector(
+            onTap: () async => await onCategorySelected(category.id),
+            child: Container(
+              margin: EdgeInsets.only(right: 12.w),
+              padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 8.h),
+              decoration: BoxDecoration(
+                color: AppColors.dictionaryCategoryBackground,
+                borderRadius: BorderRadius.circular(10.r),
+                border: Border.all(
+                  color: isSelected
+                      ? AppColors.dictionaryCategoryBorder
+                      : Colors.transparent,
+                  width: 1,
+                ),
+              ),
+              child: Center(
+                child: Text(
+                  category.getDisplayName(context.locale.languageCode),
+                  style: TextStyle(
+                    fontSize: 14.sp,
+                    fontWeight: FontWeight.w400,
+                    color: AppColors.dictionaryCategoryText,
+                  ),
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/dictionary_feature/presentation/widgets/category_selector_widget.dart
+++ b/lib/features/dictionary_feature/presentation/widgets/category_selector_widget.dart
@@ -7,7 +7,7 @@ import '../../data/dictionary_categories.dart';
 
 class CategorySelectorWidget extends StatelessWidget {
   final String selectedCategory;
-  final Future<void> Function(String) onCategorySelected;
+  final void Function(String) onCategorySelected;
 
   const CategorySelectorWidget({
     super.key,
@@ -33,7 +33,7 @@ class CategorySelectorWidget extends StatelessWidget {
           final isSelected = selectedCategory == category.id;
 
           return GestureDetector(
-            onTap: () async => await onCategorySelected(category.id),
+            onTap: () => onCategorySelected(category.id),
             child: Container(
               margin: EdgeInsets.only(right: 12.w),
               padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 8.h),

--- a/lib/features/dictionary_feature/presentation/widgets/dictionary_content_widget.dart
+++ b/lib/features/dictionary_feature/presentation/widgets/dictionary_content_widget.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+import '../../../../app/widgets/loading.dart';
+import '../../../../features/translation_feature/presentation/widgets/translation_widget.dart';
+import '../dictionary_cubit.dart';
+
+class DictionaryContentWidget extends StatelessWidget {
+  const DictionaryContentWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<DictionaryCubit, DictionaryState>(
+      builder: (context, state) {
+        final cubit = DictionaryCubit.get();
+
+        if (state is DictionaryLoading) {
+          return const Loading();
+        }
+
+        if (cubit.categoryTranslations.isEmpty) {
+          return Center(
+            child: Text(
+              'لا توجد ترجمات لهذه الفئة',
+              style: TextStyle(
+                fontSize: 16.sp,
+                color: Colors.grey,
+              ),
+            ),
+          );
+        }
+
+        return Padding(
+          padding: EdgeInsets.symmetric(horizontal: 16.w),
+          child: ListView.separated(
+            itemBuilder: (context, index) {
+              return TranslationWidget(
+                translation: cubit.categoryTranslations[index],
+              );
+            },
+            itemCount: cubit.categoryTranslations.length,
+            separatorBuilder: (context, index) => 10.verticalSpace,
+            physics: const BouncingScrollPhysics(),
+            padding: EdgeInsets.only(bottom: 20.h),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/dictionary_feature/screens/dictionary_screen.dart
+++ b/lib/features/dictionary_feature/screens/dictionary_screen.dart
@@ -1,13 +1,73 @@
 import 'package:bastet_app/features/translation_feature/presentation/widgets/translation_widget.dart';
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
+import '../../../../app/utils/app_colors.dart';
 import '../../../../app/widgets/loading.dart';
 import '../presentation/dictionary_cubit.dart';
 
-class DictionaryScreen extends StatelessWidget {
+class DictionaryScreen extends StatefulWidget {
   const DictionaryScreen({super.key});
+
+  @override
+  State<DictionaryScreen> createState() => _DictionaryScreenState();
+}
+
+class _DictionaryScreenState extends State<DictionaryScreen> {
+  String selectedCategory = "gods";
+
+  final List<Map<String, dynamic>> categories = [
+    {"id": "gods", "arabic": "آلهة", "english": "gods"},
+    {"id": "numbers", "arabic": "أرقام", "english": "numbers"},
+    {"id": "family", "arabic": "عائلة", "english": "family"},
+    {"id": "animals", "arabic": "حيوانات", "english": "animals"},
+    {"id": "colors", "arabic": "ألوان", "english": "colors"},
+    {"id": "food", "arabic": "طعام", "english": "food"},
+    {"id": "body", "arabic": "جسم", "english": "body"},
+    {"id": "symbols", "arabic": "رموز", "english": "symbols"},
+    {"id": "greetings", "arabic": "تحيات", "english": "greetings"},
+    {"id": "time", "arabic": "وقت", "english": "time"},
+    {"id": "nature", "arabic": "طبيعة", "english": "nature"},
+    {"id": "emotions", "arabic": "مشاعر", "english": "emotions"},
+    {"id": "clothes", "arabic": "ملابس", "english": "clothes"},
+    {"id": "music", "arabic": "موسيقى", "english": "music"},
+    {"id": "home", "arabic": "منزل", "english": "home"},
+    {"id": "stones", "arabic": "أحجار", "english": "stones"},
+    {"id": "temples", "arabic": "معابد", "english": "temples"},
+    {"id": "jobs", "arabic": "وظائف", "english": "jobs"},
+    {"id": "adjective", "arabic": "صفات", "english": "adjective"},
+    {"id": "verb", "arabic": "افعال", "english": "verb"},
+    {
+      "id": "words_in_egyptian_dialect",
+      "arabic": "كلمات في العامية",
+      "english": "words in egyptians dialect"
+    },
+    {"id": "prepositions", "arabic": "حروف الجر", "english": "prepositions"},
+    {"id": "insects", "arabic": "حشرات", "english": "insects"},
+    {"id": "measurements", "arabic": "قياسات", "english": "measurements"},
+    {"id": "countries", "arabic": "دول", "english": "countries"},
+    {
+      "id": "egyptian_cities_provinces",
+      "arabic": "مدن و محافظات",
+      "english": "cities and provinces"
+    },
+    {
+      "id": "fruits_vegetables",
+      "arabic": "فواكه و خضراوات",
+      "english": "fruits and vegetables"
+    },
+    {"id": "plants", "arabic": "نباتات", "english": "plants"},
+    {"id": "cosmos", "arabic": "الكون", "english": "cosmos"},
+    {"id": "female_names", "arabic": "أسماء إناث", "english": "female names"},
+    {"id": "male_names", "arabic": "أسماء ذكور", "english": "male names"},
+    {
+      "id": "kings_queens",
+      "arabic": "ملوك و ملكات",
+      "english": "kings and queens"
+    },
+  ];
 
   @override
   Widget build(BuildContext context) {
@@ -18,27 +78,93 @@ class DictionaryScreen extends StatelessWidget {
         // Load category words when the screen is first built
         if (cubit.categoryTranslations.isEmpty) {
           WidgetsBinding.instance.addPostFrameCallback((_) {
-            cubit.getCategoryWords("gods");
+            cubit.getCategoryWords(selectedCategory);
           });
         }
 
-        if (state is DictionaryLoading) {
-          return const Loading();
-        }
+        return Column(
+          children: [
+            // Category Selection
+            Container(
+              height: 50.h,
+              margin: EdgeInsets.symmetric(vertical: 16.h),
+              child: ListView.builder(
+                scrollDirection: Axis.horizontal,
+                itemCount: categories.length,
+                itemBuilder: (context, index) {
+                  final category = categories[index];
+                  final isSelected = selectedCategory == category["id"];
 
-        return Padding(
-          padding: EdgeInsets.only(right: 16.w, left: 16.w, top: 16.h),
-          child: ListView.separated(
-            itemBuilder: (context, index) {
-              return TranslationWidget(
-                translation: cubit.categoryTranslations[index],
-              );
-            },
-            itemCount: cubit.categoryTranslations.length,
-            separatorBuilder: (context, index) => 10.verticalSpace,
-            physics: const BouncingScrollPhysics(),
-            padding: EdgeInsets.only(bottom: 20.h),
-          ),
+                  return GestureDetector(
+                    onTap: () {
+                      setState(() {
+                        selectedCategory = category["id"]!;
+                      });
+                      cubit.getCategoryWords(selectedCategory);
+                    },
+                    child: Container(
+                      margin: EdgeInsets.only(right: 12.w),
+                      padding:
+                          EdgeInsets.symmetric(horizontal: 16.w, vertical: 8.h),
+                      decoration: BoxDecoration(
+                        color: const Color(0xFF3D3525),
+                        borderRadius: BorderRadius.circular(25.r),
+                        border: Border.all(
+                          color: isSelected
+                              ? const Color(0xFFE0B85B)
+                              : Colors.transparent,
+                          width: 1,
+                        ),
+                      ),
+                      child: Center(
+                        child: Text(
+                          context.locale.languageCode == "ar"
+                              ? category["arabic"]
+                              : category["english"],
+                          style: TextStyle(
+                            fontSize: 14.sp,
+                            fontWeight: FontWeight.w400,
+                            color: const Color(0xFFB1975C),
+                          ),
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+
+            // Content
+            Expanded(
+              child: state is DictionaryLoading
+                  ? const Loading()
+                  : cubit.categoryTranslations.isEmpty
+                      ? Center(
+                          child: Text(
+                            'لا توجد ترجمات لهذه الفئة',
+                            style: TextStyle(
+                              fontSize: 16.sp,
+                              color: Colors.grey,
+                            ),
+                          ),
+                        )
+                      : Padding(
+                          padding: EdgeInsets.symmetric(horizontal: 16.w),
+                          child: ListView.separated(
+                            itemBuilder: (context, index) {
+                              return TranslationWidget(
+                                translation: cubit.categoryTranslations[index],
+                              );
+                            },
+                            itemCount: cubit.categoryTranslations.length,
+                            separatorBuilder: (context, index) =>
+                                10.verticalSpace,
+                            physics: const BouncingScrollPhysics(),
+                            padding: EdgeInsets.only(bottom: 20.h),
+                          ),
+                        ),
+            ),
+          ],
         );
       },
     );

--- a/lib/features/dictionary_feature/screens/dictionary_screen.dart
+++ b/lib/features/dictionary_feature/screens/dictionary_screen.dart
@@ -1,0 +1,66 @@
+import 'package:bastet_app/features/fav_feature/presentation/presentation_logic_holder/fav_cubit/fav_cubit.dart';
+import 'package:bastet_app/features/fav_feature/presentation/widgets/empty_fav_widget.dart';
+import 'package:bastet_app/features/translation_feature/presentation/widgets/translation_widget.dart';
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+import '../../../../app/utils/app_assets.dart';
+import '../../../../app/utils/app_colors.dart';
+import '../../../../app/utils/app_strings.dart';
+import '../../../../app/widgets/custom_form_field.dart';
+import '../../../../app/widgets/image_widget.dart';
+
+class DictionaryScreen extends StatelessWidget {
+  const DictionaryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<FavCubit, FavState>(
+      builder: (context, state) {
+        final cubit = FavCubit.get();
+        return cubit.favoriteTranslations.isEmpty
+            ? const EmptyFavWidget()
+            : Padding(
+                padding: EdgeInsets.only(right: 16.w, left: 16.w, top: 16.h),
+                child: Column(
+                  children: [
+                    CustomFormField(
+                      controller: cubit.searchController,
+                      onChange: (text) {
+                        cubit.filterFavorites();
+                      },
+                      hint: AppStrings.searchHieroglyphics.tr(),
+                      hintColor: AppColors.searchHintColor,
+                      textColor: AppColors.primaryColor,
+                      fillColor: AppColors.searchFormColor,
+                      height: 50.h,
+                      prefixIconWidget: ImageWidget(
+                        imageUrl: AppAssets.search,
+                        height: 16.h,
+                        width: 16.w,
+                      ),
+                      borderRadiusValue: 50.r,
+                    ),
+                    20.verticalSpace,
+                    Expanded(
+                      child: ListView.separated(
+                        itemBuilder: (context, index) {
+                          return TranslationWidget(
+                            translation: cubit.filteredTranslations[index],
+                          );
+                        },
+                        itemCount: cubit.filteredTranslations.length,
+                        separatorBuilder: (context, index) => 10.verticalSpace,
+                        physics: const BouncingScrollPhysics(),
+                        padding: EdgeInsets.only(bottom: 20.h),
+                      ),
+                    ),
+                  ],
+                ),
+              );
+      },
+    );
+  }
+}

--- a/lib/features/dictionary_feature/screens/dictionary_screen.dart
+++ b/lib/features/dictionary_feature/screens/dictionary_screen.dart
@@ -1,12 +1,10 @@
-import 'package:bastet_app/features/translation_feature/presentation/widgets/translation_widget.dart';
-import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
-import '../../../../app/utils/app_colors.dart';
-import '../../../../app/widgets/loading.dart';
+import '../../../../app/utils/consts.dart';
 import '../presentation/dictionary_cubit.dart';
+import '../presentation/widgets/category_selector_widget.dart';
+import '../presentation/widgets/dictionary_content_widget.dart';
 
 class DictionaryScreen extends StatefulWidget {
   const DictionaryScreen({super.key});
@@ -21,157 +19,50 @@ class _DictionaryScreenState extends State<DictionaryScreen> {
   @override
   void initState() {
     super.initState();
-    // Ensure the initial category is loaded
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) {
-        DictionaryCubit.get().getCategoryWords(selectedCategory);
-      }
-    });
+    _loadSelectedCategory();
   }
 
-  final List<Map<String, dynamic>> categories = [
-    {"id": "gods", "arabic": "آلهة", "english": "gods"},
-    {"id": "numbers", "arabic": "أرقام", "english": "numbers"},
-    {"id": "family", "arabic": "عائلة", "english": "family"},
-    {"id": "animals", "arabic": "حيوانات", "english": "animals"},
-    {"id": "colors", "arabic": "ألوان", "english": "colors"},
-    {"id": "food", "arabic": "طعام", "english": "food"},
-    {"id": "body", "arabic": "جسم", "english": "body"},
-    {"id": "symbols", "arabic": "رموز", "english": "symbols"},
-    {"id": "greetings", "arabic": "تحيات", "english": "greetings"},
-    {"id": "time", "arabic": "وقت", "english": "time"},
-    {"id": "nature", "arabic": "طبيعة", "english": "nature"},
-    {"id": "emotions", "arabic": "مشاعر", "english": "emotions"},
-    {"id": "clothes", "arabic": "ملابس", "english": "clothes"},
-    {"id": "music", "arabic": "موسيقى", "english": "music"},
-    {"id": "home", "arabic": "منزل", "english": "home"},
-    {"id": "stones", "arabic": "أحجار", "english": "stones"},
-    {"id": "temples", "arabic": "معابد", "english": "temples"},
-    {"id": "jobs", "arabic": "وظائف", "english": "jobs"},
-    {"id": "adjective", "arabic": "صفات", "english": "adjective"},
-    {"id": "verb", "arabic": "افعال", "english": "verb"},
-    {
-      "id": "words_in_egyptian_dialect",
-      "arabic": "كلمات في العامية",
-      "english": "words in egyptians dialect"
-    },
-    {"id": "prepositions", "arabic": "حروف الجر", "english": "prepositions"},
-    {"id": "insects", "arabic": "حشرات", "english": "insects"},
-    {"id": "measurements", "arabic": "قياسات", "english": "measurements"},
-    {"id": "countries", "arabic": "دول", "english": "countries"},
-    {
-      "id": "egyptian_cities_provinces",
-      "arabic": "مدن و محافظات",
-      "english": "cities and provinces"
-    },
-    {
-      "id": "fruits_vegetables",
-      "arabic": "فواكه و خضراوات",
-      "english": "fruits and vegetables"
-    },
-    {"id": "plants", "arabic": "نباتات", "english": "plants"},
-    {"id": "cosmos", "arabic": "الكون", "english": "cosmos"},
-    {"id": "female_names", "arabic": "أسماء إناث", "english": "female names"},
-    {"id": "male_names", "arabic": "أسماء ذكور", "english": "male names"},
-    {
-      "id": "kings_queens",
-      "arabic": "ملوك و ملكات",
-      "english": "kings and queens"
-    },
-  ];
+  Future<void> _loadSelectedCategory() async {
+    final prefs = await SharedPreferences.getInstance();
+    final savedCategory = prefs.getString(kSelectedDictionaryCategory);
+
+    if (savedCategory != null) {
+      setState(() {
+        selectedCategory = savedCategory;
+      });
+    }
+
+    // Load the category data
+    if (mounted) {
+      DictionaryCubit.get().getCategoryWords(selectedCategory);
+    }
+  }
+
+  Future<void> _onCategorySelected(String categoryId) async {
+    setState(() {
+      selectedCategory = categoryId;
+    });
+
+    // Save the selected category
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(kSelectedDictionaryCategory, categoryId);
+
+    // Load the category data
+    DictionaryCubit.get().getCategoryWords(categoryId);
+  }
 
   @override
   Widget build(BuildContext context) {
-    return BlocBuilder<DictionaryCubit, DictionaryState>(
-      builder: (context, state) {
-        final cubit = DictionaryCubit.get();
-
-        return Column(
-          children: [
-            // Category Selection
-            Container(
-              height: 40.h,
-              margin: EdgeInsets.only(
-                  top: 10.h, bottom: 25.h, right: 8.w, left: 8.w),
-              child: ListView.builder(
-                scrollDirection: Axis.horizontal,
-                itemCount: categories.length,
-                itemBuilder: (context, index) {
-                  final category = categories[index];
-                  final isSelected = selectedCategory == category["id"];
-
-                  return GestureDetector(
-                    onTap: () {
-                      setState(() {
-                        selectedCategory = category["id"]!;
-                      });
-                      cubit.getCategoryWords(selectedCategory);
-                    },
-                    child: Container(
-                      margin: EdgeInsets.only(right: 12.w),
-                      padding:
-                          EdgeInsets.symmetric(horizontal: 16.w, vertical: 8.h),
-                      decoration: BoxDecoration(
-                        color: AppColors.dictionaryCategoryBackground,
-                        borderRadius: BorderRadius.circular(10.r),
-                        border: Border.all(
-                          color: isSelected
-                              ? AppColors.dictionaryCategoryBorder
-                              : Colors.transparent,
-                          width: 1,
-                        ),
-                      ),
-                      child: Center(
-                        child: Text(
-                          context.locale.languageCode == "ar"
-                              ? category["arabic"]
-                              : category["english"],
-                          style: TextStyle(
-                            fontSize: 14.sp,
-                            fontWeight: FontWeight.w400,
-                            color: AppColors.dictionaryCategoryText,
-                          ),
-                        ),
-                      ),
-                    ),
-                  );
-                },
-              ),
-            ),
-
-            // Content
-            Expanded(
-              child: state is DictionaryLoading
-                  ? const Loading()
-                  : cubit.categoryTranslations.isEmpty
-                      ? Center(
-                          child: Text(
-                            'لا توجد ترجمات لهذه الفئة',
-                            style: TextStyle(
-                              fontSize: 16.sp,
-                              color: Colors.grey,
-                            ),
-                          ),
-                        )
-                      : Padding(
-                          padding: EdgeInsets.symmetric(horizontal: 16.w),
-                          child: ListView.separated(
-                            itemBuilder: (context, index) {
-                              return TranslationWidget(
-                                translation: cubit.categoryTranslations[index],
-                              );
-                            },
-                            itemCount: cubit.categoryTranslations.length,
-                            separatorBuilder: (context, index) =>
-                                10.verticalSpace,
-                            physics: const BouncingScrollPhysics(),
-                            padding: EdgeInsets.only(bottom: 20.h),
-                          ),
-                        ),
-            ),
-          ],
-        );
-      },
+    return Column(
+      children: [
+        CategorySelectorWidget(
+          selectedCategory: selectedCategory,
+          onCategorySelected: _onCategorySelected,
+        ),
+        const Expanded(
+          child: DictionaryContentWidget(),
+        ),
+      ],
     );
   }
 }

--- a/lib/features/dictionary_feature/screens/dictionary_screen.dart
+++ b/lib/features/dictionary_feature/screens/dictionary_screen.dart
@@ -18,6 +18,17 @@ class DictionaryScreen extends StatefulWidget {
 class _DictionaryScreenState extends State<DictionaryScreen> {
   String selectedCategory = "gods";
 
+  @override
+  void initState() {
+    super.initState();
+    // Ensure the initial category is loaded
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        DictionaryCubit.get().getCategoryWords(selectedCategory);
+      }
+    });
+  }
+
   final List<Map<String, dynamic>> categories = [
     {"id": "gods", "arabic": "آلهة", "english": "gods"},
     {"id": "numbers", "arabic": "أرقام", "english": "numbers"},
@@ -75,19 +86,13 @@ class _DictionaryScreenState extends State<DictionaryScreen> {
       builder: (context, state) {
         final cubit = DictionaryCubit.get();
 
-        // Load category words when the screen is first built
-        if (cubit.categoryTranslations.isEmpty) {
-          WidgetsBinding.instance.addPostFrameCallback((_) {
-            cubit.getCategoryWords(selectedCategory);
-          });
-        }
-
         return Column(
           children: [
             // Category Selection
             Container(
-              height: 50.h,
-              margin: EdgeInsets.symmetric(vertical: 16.h),
+              height: 40.h,
+              margin: EdgeInsets.only(
+                  top: 10.h, bottom: 25.h, right: 8.w, left: 8.w),
               child: ListView.builder(
                 scrollDirection: Axis.horizontal,
                 itemCount: categories.length,
@@ -107,11 +112,11 @@ class _DictionaryScreenState extends State<DictionaryScreen> {
                       padding:
                           EdgeInsets.symmetric(horizontal: 16.w, vertical: 8.h),
                       decoration: BoxDecoration(
-                        color: const Color(0xFF3D3525),
-                        borderRadius: BorderRadius.circular(25.r),
+                        color: AppColors.dictionaryCategoryBackground,
+                        borderRadius: BorderRadius.circular(10.r),
                         border: Border.all(
                           color: isSelected
-                              ? const Color(0xFFE0B85B)
+                              ? AppColors.dictionaryCategoryBorder
                               : Colors.transparent,
                           width: 1,
                         ),
@@ -124,7 +129,7 @@ class _DictionaryScreenState extends State<DictionaryScreen> {
                           style: TextStyle(
                             fontSize: 14.sp,
                             fontWeight: FontWeight.w400,
-                            color: const Color(0xFFB1975C),
+                            color: AppColors.dictionaryCategoryText,
                           ),
                         ),
                       ),

--- a/lib/features/dictionary_feature/screens/dictionary_screen.dart
+++ b/lib/features/dictionary_feature/screens/dictionary_screen.dart
@@ -1,65 +1,45 @@
-import 'package:bastet_app/features/fav_feature/presentation/presentation_logic_holder/fav_cubit/fav_cubit.dart';
-import 'package:bastet_app/features/fav_feature/presentation/widgets/empty_fav_widget.dart';
 import 'package:bastet_app/features/translation_feature/presentation/widgets/translation_widget.dart';
-import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
-import '../../../../app/utils/app_assets.dart';
-import '../../../../app/utils/app_colors.dart';
-import '../../../../app/utils/app_strings.dart';
-import '../../../../app/widgets/custom_form_field.dart';
-import '../../../../app/widgets/image_widget.dart';
+import '../../../../app/widgets/loading.dart';
+import '../presentation/dictionary_cubit.dart';
 
 class DictionaryScreen extends StatelessWidget {
   const DictionaryScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return BlocBuilder<FavCubit, FavState>(
+    return BlocBuilder<DictionaryCubit, DictionaryState>(
       builder: (context, state) {
-        final cubit = FavCubit.get();
-        return cubit.favoriteTranslations.isEmpty
-            ? const EmptyFavWidget()
-            : Padding(
-                padding: EdgeInsets.only(right: 16.w, left: 16.w, top: 16.h),
-                child: Column(
-                  children: [
-                    CustomFormField(
-                      controller: cubit.searchController,
-                      onChange: (text) {
-                        cubit.filterFavorites();
-                      },
-                      hint: AppStrings.searchHieroglyphics.tr(),
-                      hintColor: AppColors.searchHintColor,
-                      textColor: AppColors.primaryColor,
-                      fillColor: AppColors.searchFormColor,
-                      height: 50.h,
-                      prefixIconWidget: ImageWidget(
-                        imageUrl: AppAssets.search,
-                        height: 16.h,
-                        width: 16.w,
-                      ),
-                      borderRadiusValue: 50.r,
-                    ),
-                    20.verticalSpace,
-                    Expanded(
-                      child: ListView.separated(
-                        itemBuilder: (context, index) {
-                          return TranslationWidget(
-                            translation: cubit.filteredTranslations[index],
-                          );
-                        },
-                        itemCount: cubit.filteredTranslations.length,
-                        separatorBuilder: (context, index) => 10.verticalSpace,
-                        physics: const BouncingScrollPhysics(),
-                        padding: EdgeInsets.only(bottom: 20.h),
-                      ),
-                    ),
-                  ],
-                ),
+        final cubit = DictionaryCubit.get();
+
+        // Load category words when the screen is first built
+        if (cubit.categoryTranslations.isEmpty) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            cubit.getCategoryWords("gods");
+          });
+        }
+
+        if (state is DictionaryLoading) {
+          return const Loading();
+        }
+
+        return Padding(
+          padding: EdgeInsets.only(right: 16.w, left: 16.w, top: 16.h),
+          child: ListView.separated(
+            itemBuilder: (context, index) {
+              return TranslationWidget(
+                translation: cubit.categoryTranslations[index],
               );
+            },
+            itemCount: cubit.categoryTranslations.length,
+            separatorBuilder: (context, index) => 10.verticalSpace,
+            physics: const BouncingScrollPhysics(),
+            padding: EdgeInsets.only(bottom: 20.h),
+          ),
+        );
       },
     );
   }

--- a/lib/features/dictionary_feature/screens/dictionary_screen.dart
+++ b/lib/features/dictionary_feature/screens/dictionary_screen.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
-import '../../../../app/utils/consts.dart';
 import '../presentation/dictionary_cubit.dart';
 import '../presentation/widgets/category_selector_widget.dart';
 import '../presentation/widgets/dictionary_content_widget.dart';
@@ -19,33 +17,18 @@ class _DictionaryScreenState extends State<DictionaryScreen> {
   @override
   void initState() {
     super.initState();
-    _loadSelectedCategory();
+    // Load the initial category data
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        DictionaryCubit.get().getCategoryWords(selectedCategory);
+      }
+    });
   }
 
-  Future<void> _loadSelectedCategory() async {
-    final prefs = await SharedPreferences.getInstance();
-    final savedCategory = prefs.getString(kSelectedDictionaryCategory);
-
-    if (savedCategory != null) {
-      setState(() {
-        selectedCategory = savedCategory;
-      });
-    }
-
-    // Load the category data
-    if (mounted) {
-      DictionaryCubit.get().getCategoryWords(selectedCategory);
-    }
-  }
-
-  Future<void> _onCategorySelected(String categoryId) async {
+  void _onCategorySelected(String categoryId) {
     setState(() {
       selectedCategory = categoryId;
     });
-
-    // Save the selected category
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(kSelectedDictionaryCategory, categoryId);
 
     // Load the category data
     DictionaryCubit.get().getCategoryWords(categoryId);

--- a/lib/features/translation_feature/data/data_source/translation_remote_data_source.dart
+++ b/lib/features/translation_feature/data/data_source/translation_remote_data_source.dart
@@ -24,7 +24,13 @@ abstract class TranslationRemoteDataSource {
 
   /// Calls the [GET] {word} endpoint.
   /// Throws a [ServerException] for all error codes.
-  Future<LiteralTranslationModel> literalTranslation(Map<String, dynamic> params);
+  Future<LiteralTranslationModel> literalTranslation(
+      Map<String, dynamic> params);
+
+  /// Calls the [GET] {category/:category_id/words} endpoint.
+  /// Throws a [ServerException] for all error codes.
+  Future<TranslationModel> getDictionaryCategoryWords(
+      Map<String, String> params);
 }
 
 class TranslationRemoteDataSourceImpl implements TranslationRemoteDataSource {
@@ -71,5 +77,15 @@ class TranslationRemoteDataSourceImpl implements TranslationRemoteDataSource {
     );
     final data = await RemoteDataSourceCallHandler()(response);
     return LiteralTranslationModel.fromJson(data);
+  }
+
+  @override
+  Future<TranslationModel> getDictionaryCategoryWords(params) async {
+    final response = await networkManager.request(
+      endPoint: '$kCategory/${params['category_id']}/words',
+      method: RequestMethod.get,
+    );
+    final data = await RemoteDataSourceCallHandler()(response);
+    return TranslationModel.fromJson(data);
   }
 }

--- a/lib/features/translation_feature/data/repo_impl/translation_repo_impl.dart
+++ b/lib/features/translation_feature/data/repo_impl/translation_repo_impl.dart
@@ -15,7 +15,8 @@ class TranslationRepoImpl extends TranslationRepo {
   final TranslationRemoteDataSource translationRemoteDataSource;
   final NetworkInfo networkInfo;
 
-  TranslationRepoImpl({required this.networkInfo, required this.translationRemoteDataSource});
+  TranslationRepoImpl(
+      {required this.networkInfo, required this.translationRemoteDataSource});
 
   @override
   Future<Either<Failure, TranslationModel>> getTranslation(params) async {
@@ -25,16 +26,19 @@ class TranslationRepoImpl extends TranslationRepo {
   }
 
   @override
-  Future<Either<Failure, LiteralTranslationModel>> getLiteralTranslation(params) async {
-    return await RepoImplCallHandler<LiteralTranslationModel>(networkInfo)(() async {
+  Future<Either<Failure, LiteralTranslationModel>> getLiteralTranslation(
+      params) async {
+    return await RepoImplCallHandler<LiteralTranslationModel>(networkInfo)(
+        () async {
       return await translationRemoteDataSource.literalTranslation(params);
     });
   }
 
-
   @override
-  Future<Either<Failure, TranslationDetailsModel>> getTranslationDetails(params) async {
-    return await RepoImplCallHandler<TranslationDetailsModel>(networkInfo)(() async {
+  Future<Either<Failure, TranslationDetailsModel>> getTranslationDetails(
+      params) async {
+    return await RepoImplCallHandler<TranslationDetailsModel>(networkInfo)(
+        () async {
       return await translationRemoteDataSource.getWordDetails(params);
     });
   }
@@ -43,6 +47,15 @@ class TranslationRepoImpl extends TranslationRepo {
   Future<Either<Failure, void>> suggestWord(params) async {
     return await RepoImplCallHandler<void>(networkInfo)(() async {
       return await translationRemoteDataSource.suggestWord(params);
+    });
+  }
+
+  @override
+  Future<Either<Failure, TranslationModel>> getDictionaryCategoryWords(
+      params) async {
+    return await RepoImplCallHandler<TranslationModel>(networkInfo)(() async {
+      return await translationRemoteDataSource
+          .getDictionaryCategoryWords(params);
     });
   }
 }

--- a/lib/features/translation_feature/domain/repo/translation_repo.dart
+++ b/lib/features/translation_feature/domain/repo/translation_repo.dart
@@ -6,8 +6,13 @@ import '../../data/model/translation_model.dart';
 import '../../data/model/literal_translation.dart';
 
 abstract class TranslationRepo {
-  Future<Either<Failure, TranslationModel>> getTranslation(Map<String, String> params);
-  Future<Either<Failure, TranslationDetailsModel>> getTranslationDetails(Map<String, String> params);
-  Future<Either<Failure, LiteralTranslationModel>> getLiteralTranslation(Map<String, dynamic> params);
+  Future<Either<Failure, TranslationModel>> getTranslation(
+      Map<String, String> params);
+  Future<Either<Failure, TranslationDetailsModel>> getTranslationDetails(
+      Map<String, String> params);
+  Future<Either<Failure, LiteralTranslationModel>> getLiteralTranslation(
+      Map<String, dynamic> params);
   Future<Either<Failure, void>> suggestWord(Map<String, dynamic> params);
+  Future<Either<Failure, TranslationModel>> getDictionaryCategoryWords(
+      Map<String, String> params);
 }

--- a/lib/features/translation_feature/domain/usecases/get_dictionary_category_words_usecase.dart
+++ b/lib/features/translation_feature/domain/usecases/get_dictionary_category_words_usecase.dart
@@ -1,0 +1,28 @@
+import 'package:bastet_app/app/error/failures.dart';
+
+import 'package:dartz/dartz.dart';
+
+import '../../../../app/usecase/usecase.dart';
+import '../../data/model/translation_model.dart';
+import '../repo/translation_repo.dart';
+
+class GetDictionaryCategoryWordsUsecase
+    implements
+        UseCase<TranslationModel, GetDictionaryCategoryWordsUseCaseParams> {
+  final TranslationRepo repository;
+
+  GetDictionaryCategoryWordsUsecase({required this.repository});
+
+  @override
+  Future<Either<Failure, TranslationModel>> call(params) async {
+    return await repository.getDictionaryCategoryWords(params.toMap());
+  }
+}
+
+class GetDictionaryCategoryWordsUseCaseParams {
+  final String categoryId;
+
+  GetDictionaryCategoryWordsUseCaseParams({required this.categoryId});
+
+  Map<String, String> toMap() => {'category_id': categoryId};
+}

--- a/lib/features/translation_feature/presentation/screens/tab_bar_screen.dart
+++ b/lib/features/translation_feature/presentation/screens/tab_bar_screen.dart
@@ -1,3 +1,4 @@
+import 'package:bastet_app/features/dictionary_feature/screens/dictionary_screen.dart';
 import 'package:bastet_app/features/fav_feature/presentation/presentation_logic_holder/fav_cubit/fav_cubit.dart';
 import 'package:bastet_app/features/fav_feature/presentation/screens/fav_screen.dart';
 import 'package:easy_localization/easy_localization.dart';
@@ -18,14 +19,17 @@ class TabBarScreen extends StatefulWidget {
   State<TabBarScreen> createState() => _TabBarScreenState();
 }
 
-class _TabBarScreenState extends State<TabBarScreen> with SingleTickerProviderStateMixin {
-
+class _TabBarScreenState extends State<TabBarScreen>
+    with SingleTickerProviderStateMixin {
   late TabController tabController;
 
   @override
   void initState() {
     super.initState();
-    tabController = TabController(length: 2, vsync: this,);
+    tabController = TabController(
+      length: 3,
+      vsync: this,
+    );
     tabController.addListener(_removeKeyboard);
     FavCubit.get().getFavorites();
   }
@@ -48,7 +52,7 @@ class _TabBarScreenState extends State<TabBarScreen> with SingleTickerProviderSt
       appBar: AppBar(
         backgroundColor: const Color(0xFF2C2924),
         actions: [
-          if (context.locale.languageCode=="ar")...[
+          if (context.locale.languageCode == "ar") ...[
             Builder(
               builder: (BuildContext context) {
                 return IconButton(
@@ -67,24 +71,24 @@ class _TabBarScreenState extends State<TabBarScreen> with SingleTickerProviderSt
             ),
           ],
         ],
-        leading: context.locale.languageCode=="en"
-          ? Builder(
-          builder: (BuildContext context) {
-            return IconButton(
-              onPressed: () => Scaffold.of(context).openDrawer(),
-              icon: const Icon(
-                Icons.menu,
-              ),
-              isSelected: true,
-              selectedIcon: ImageWidget(
-                imageUrl: AppAssets.drawer,
-                width: 32.w,
-                height: 32.h,
-              ),
-            );
-          },
-        )
-          : null,
+        leading: context.locale.languageCode == "en"
+            ? Builder(
+                builder: (BuildContext context) {
+                  return IconButton(
+                    onPressed: () => Scaffold.of(context).openDrawer(),
+                    icon: const Icon(
+                      Icons.menu,
+                    ),
+                    isSelected: true,
+                    selectedIcon: ImageWidget(
+                      imageUrl: AppAssets.drawer,
+                      width: 32.w,
+                      height: 32.h,
+                    ),
+                  );
+                },
+              )
+            : null,
         bottom: TabBar(
           controller: tabController,
           indicatorColor: AppColors.secondaryColor,
@@ -100,6 +104,13 @@ class _TabBarScreenState extends State<TabBarScreen> with SingleTickerProviderSt
             ),
             Tab(
               child: ImageWidget(
+                imageUrl: AppAssets.dictionary,
+                width: 30.w,
+                height: 30.h,
+              ),
+            ),
+            Tab(
+              child: ImageWidget(
                 imageUrl: AppAssets.fav,
                 width: 32.w,
                 height: 32.h,
@@ -108,12 +119,14 @@ class _TabBarScreenState extends State<TabBarScreen> with SingleTickerProviderSt
           ],
         ),
       ),
-      endDrawer: context.locale.languageCode=="ar" ? const DrawerWidget() : null,
-      drawer: context.locale.languageCode=="en" ? const DrawerWidget() : null,
+      endDrawer:
+          context.locale.languageCode == "ar" ? const DrawerWidget() : null,
+      drawer: context.locale.languageCode == "en" ? const DrawerWidget() : null,
       body: TabBarView(
         controller: tabController,
         children: const [
           TranslationScreen(),
+          DictionaryScreen(),
           FavScreen(),
         ],
       ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,6 +18,7 @@ import 'features/translation_feature/data/model/english.dart';
 import 'features/translation_feature/data/model/translation.dart';
 import 'features/settings_feature/presentation/presentation_logic_holder/settings_cubit/settings_cubit.dart';
 import 'features/translation_feature/presentation/presentation_logic_holder/translation_cubit/translation_cubit.dart';
+import 'features/dictionary_feature/presentation/dictionary_cubit.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -44,6 +45,9 @@ Future<void> main() async {
         ),
         BlocProvider<FavCubit>(
           create: (BuildContext context) => FavCubit(),
+        ),
+        BlocProvider<DictionaryCubit>(
+          create: (BuildContext context) => DictionaryCubit(),
         ),
       ],
       child: const MyApp(),
@@ -86,7 +90,8 @@ class MyApp extends StatelessWidget {
           navigatorKey: getIt<NavHelper>().navigatorKey,
           builder: (context, widget) {
             return MediaQuery(
-              data: MediaQuery.of(context).copyWith(textScaler: const TextScaler.linear(1.0)),
+              data: MediaQuery.of(context)
+                  .copyWith(textScaler: const TextScaler.linear(1.0)),
               child: widget!,
             );
           },

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.3.12+17
+version: 1.4.0+18
 
 environment:
   sdk: '>=3.4.1 <4.0.0'


### PR DESCRIPTION
### **User description**
## Adding new dictionary screen with multiplie categories

<img width="357" height="776" alt="image" src="https://github.com/user-attachments/assets/8f5f22b9-0c04-4e8c-a739-da885c59ab3b" />


___

### **PR Type**
Enhancement


___

### **Description**
- Add comprehensive dictionary feature with category-based word browsing

- Implement category selection with persistent storage using SharedPreferences

- Create new UI components for category selector and dictionary content

- Integrate dictionary screen into main tab navigation


___

### **Changes diagram**

```mermaid
flowchart LR
  A["User selects category"] --> B["CategorySelectorWidget"]
  B --> C["DictionaryCubit"]
  C --> D["GetDictionaryCategoryWordsUsecase"]
  D --> E["TranslationRemoteDataSource"]
  E --> F["API endpoint"]
  F --> G["DictionaryContentWidget"]
  G --> H["Display translations"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>app_colors.dart</strong><dd><code>Add dictionary category color constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bastet00/bastet-app/pull/22/files#diff-dc9c61faf3bb66492a62b0b825d5169fb95a9a238a3a54479af9b2d3fd3cf830">+7/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>consts.dart</strong><dd><code>Add dictionary-related constants and SharedPreferences keys</code></dd></td>
  <td><a href="https://github.com/bastet00/bastet-app/pull/22/files#diff-340faf6fe3ad79bec0fd88e85f15af9f153a69941a38a18ab3a8a25f5cf0b86c">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.dart</strong><dd><code>Register DictionaryCubit in BlocProvider setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bastet00/bastet-app/pull/22/files#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AndroidManifest.xml</strong><dd><code>Enable back navigation callback in Android manifest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bastet00/bastet-app/pull/22/files#diff-63272c98a6330850888e633b43ba4c9decee6431a115e0d2731564838eaa1d1d">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>get_it_injection.dart</strong><dd><code>Register new dictionary use case in dependency injection</code>&nbsp; </dd></td>
  <td><a href="https://github.com/bastet00/bastet-app/pull/22/files#diff-ef7cfbd08c1c665e57d60f846ef8fd618f3b39ea9ea980a429151a878725f125">+30/-13</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td><strong>dictionary_categories.dart</strong><dd><code>Define dictionary categories data model and static list</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bastet00/bastet-app/pull/22/files#diff-d5b573a0bd2b081226b2f9b6e46ae2acc6cd0d2cdacf5f6b5354c4fbdf7307b4">+68/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dictionary_cubit.dart</strong><dd><code>Implement state management for dictionary category words</code>&nbsp; </dd></td>
  <td><a href="https://github.com/bastet00/bastet-app/pull/22/files#diff-c0bae1222af4213b21450303b8060a4b2c97b900a5e1a344c921a858afee4502">+44/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dictionary_state.dart</strong><dd><code>Define dictionary feature state classes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bastet00/bastet-app/pull/22/files#diff-25499c219a3763d37a9d58181317e2258430324f7dbc61b6dc6cd6549107b598">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>category_selector_widget.dart</strong><dd><code>Create horizontal category selection widget</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bastet00/bastet-app/pull/22/files#diff-9d677f5bef584a7cfd0a513abaae9bbbe390ef34f24c381e8feccb66aee2d402">+66/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dictionary_content_widget.dart</strong><dd><code>Build content display widget for dictionary translations</code>&nbsp; </dd></td>
  <td><a href="https://github.com/bastet00/bastet-app/pull/22/files#diff-e14d39d005882c95654f0d7f6a1786a2772f8fae3d1b48ce5704131362008db9">+51/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dictionary_screen.dart</strong><dd><code>Implement main dictionary screen with category persistence</code></dd></td>
  <td><a href="https://github.com/bastet00/bastet-app/pull/22/files#diff-5ace2e68bafeffca87c04f09f4c93e79f68c4d8c62d8ed3ba2e46783df0015a8">+68/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>translation_remote_data_source.dart</strong><dd><code>Add API method for fetching dictionary category words</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bastet00/bastet-app/pull/22/files#diff-cc7aeac863f4ec43b06c4cbad5f5d6a60f7eb76124a93d269245054a95afcca0">+18/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>translation_repo_impl.dart</strong><dd><code>Implement repository method for dictionary category words</code></dd></td>
  <td><a href="https://github.com/bastet00/bastet-app/pull/22/files#diff-9d7f9262e2861c260eef8e53288d9f14de5a312d61b37294879f3ed3150ec11d">+20/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>translation_repo.dart</strong><dd><code>Add abstract method for dictionary category words</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bastet00/bastet-app/pull/22/files#diff-e629bba2426baf3862c8e65cf0d2dcbbdb358fb7aa377f3f8f5909409f8d5fdf">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>get_dictionary_category_words_usecase.dart</strong><dd><code>Create use case for fetching dictionary category words</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bastet00/bastet-app/pull/22/files#diff-4ae0f5fc0015512f2960f9ee6f3e7c551ff86bfff3fb4be7ff50e2a2d8cbbdf2">+28/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tab_bar_screen.dart</strong><dd><code>Add dictionary tab to main navigation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bastet00/bastet-app/pull/22/files#diff-dbb2315dae54c66708c087398dc6a2a7799ebaa0d6967fc8d9062e97fb89e9ba">+37/-24</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>.metadata</strong><dd><code>Update Flutter platform metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bastet00/bastet-app/pull/22/files#diff-ae117ad88f1f97fea8c12089fd5dd35b16a5a3541272cbf49e681a3ae726eec3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>